### PR TITLE
Adds go1.18 to tests, moves default version to 1.17

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
 env:
-  DEFAULT_GO_VERSION: 1.16
+  DEFAULT_GO_VERSION: 1.17
 jobs:
   benchmark:
     name: Benchmarks

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -4,7 +4,7 @@ on:
     branches:
       - main
 env:
-  DEFAULT_GO_VERSION: 1.17
+  DEFAULT_GO_VERSION: 1.16
 jobs:
   benchmark:
     name: Benchmarks

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
   # Path to where test results will be saved.
   TEST_RESULTS: /tmp/test-results
   # Default minimum version of Go to support.
-  DEFAULT_GO_VERSION: 1.16
+  DEFAULT_GO_VERSION: 1.17
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -109,7 +109,7 @@ jobs:
   compatibility-test:
     strategy:
       matrix:
-        go-version: [1.17, 1.16]
+        go-version: [1.18, 1.17, 1.16]
         os: [ubuntu-latest, macos-latest, windows-latest]
         # GitHub Actions does not support arm* architectures on default
         # runners. It is possible to acomplish this with a self-hosted runner

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ env:
   # Path to where test results will be saved.
   TEST_RESULTS: /tmp/test-results
   # Default minimum version of Go to support.
-  DEFAULT_GO_VERSION: 1.17
+  DEFAULT_GO_VERSION: 1.16
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,7 +35,7 @@ This update is a breaking change of the unstable Metrics API. Code instrumented 
   Zero or negative values will not be changed to the default value like `WithSpanLimits` does.
   Setting a limit to zero will effectively disable the related resource it limits and setting to a negative value will mean that resource is unlimited.
   Consequentially, limits should be constructed using `NewSpanLimits` and updated accordingly. (#2637)
-- Add go 1.18 to our compatibility tests. (#????)
+- Add go 1.18 to our compatibility tests. (#2679)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ This update is a breaking change of the unstable Metrics API. Code instrumented 
   Zero or negative values will not be changed to the default value like `WithSpanLimits` does.
   Setting a limit to zero will effectively disable the related resource it limits and setting to a negative value will mean that resource is unlimited.
   Consequentially, limits should be constructed using `NewSpanLimits` and updated accordingly. (#2637)
+- Add go 1.18 to our compatibility tests. (#????)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,10 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 This update is a breaking change of the unstable Metrics API.
 Code instrumented with the `go.opentelemetry.io/otel/metric` will need to be modified.
 
+### Added
+
+- Add go 1.18 to our compatibility tests. (#2679)
+
 ### Changed
 
 - The metrics API has been significantly changed. (#2587)
@@ -46,7 +50,6 @@ Code instrumented with the `go.opentelemetry.io/otel/metric` will need to be mod
   Zero or negative values will not be changed to the default value like `WithSpanLimits` does.
   Setting a limit to zero will effectively disable the related resource it limits and setting to a negative value will mean that resource is unlimited.
   Consequentially, limits should be constructed using `NewSpanLimits` and updated accordingly. (#2637)
-- Add go 1.18 to our compatibility tests. (#2679)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ This project is tested on the following systems.
 While this project should work for other systems, no compatibility guarantees
 are made for those systems currently.
 
-Go 1.18 was added in March of 2022.  Go 1.16 will be removed around June 2022
+Go 1.18 was added in March of 2022.
+Go 1.16 will be removed around June 2022.
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -41,19 +41,26 @@ This project is tested on the following systems.
 
 | OS      | Go Version | Architecture |
 | ------- | ---------- | ------------ |
+| Ubuntu  | 1.18       | amd64        |
 | Ubuntu  | 1.17       | amd64        |
 | Ubuntu  | 1.16       | amd64        |
+| Ubuntu  | 1.18       | 386          |
 | Ubuntu  | 1.17       | 386          |
 | Ubuntu  | 1.16       | 386          |
+| MacOS   | 1.18       | amd64        |
 | MacOS   | 1.17       | amd64        |
 | MacOS   | 1.16       | amd64        |
+| Windows | 1.18       | amd64        |
 | Windows | 1.17       | amd64        |
 | Windows | 1.16       | amd64        |
+| Windows | 1.18       | 386          |
 | Windows | 1.17       | 386          |
 | Windows | 1.16       | 386          |
 
 While this project should work for other systems, no compatibility guarantees
 are made for those systems currently.
+
+Go 1.18 was added in March of 2022.  Go 1.16 will be removed around June 2022
 
 ## Getting Started
 


### PR DESCRIPTION
This introduces go 1.18